### PR TITLE
Add beatmaps.file_name index

### DIFF
--- a/migrations/0003_add_beatmaps_filename_idx.up.sql
+++ b/migrations/0003_add_beatmaps_filename_idx.up.sql
@@ -1,0 +1,1 @@
+alter table beatmaps add index (file_name);


### PR DESCRIPTION
Noticed as a common slow query via datadog monitoring: https://app.datadoghq.com/logs?query=source%3Amysql%20%40db.operation%3A%2A%20%40duration%3A%3E1s%20%40db.statement%3A%2Afile_name%2A%20&agg_m=count&agg_m_source=base&agg_t=count&cols=status%2Chost%2C%40db.operation%2C%40duration&fromUser=true&integration_id=mysql&integration_short_name=slow_operations&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=%40duration%2Cdesc&viz=stream&from_ts=1718703976969&to_ts=1718790376969&live=true

And that it does not currently have an index:
![image](https://i.cmyui.xyz/RvNVZt6Xvgsg8e3X9x4.png)

From local testing:
```sql
mysql> explain analyze SELECT 1 FROM beatmaps WHERE file_name = 'kozato - Rengetsu Ouka (ktgster) [O].osu'\G
*************************** 1. row ***************************
EXPLAIN: -> Filter: (beatmaps.file_name = 'kozato - Rengetsu Ouka (ktgster) [O].osu')  (cost=106904 rows=97810) (actual time=429..429 rows=0 loops=1)
    -> Table scan on beatmaps  (cost=106904 rows=978097) (actual time=0.0549..387 rows=1.01e+6 loops=1)

1 row in set (0.43 sec)

mysql> alter table beatmaps add index (file_name);
Query OK, 0 rows affected (14.24 sec)
Records: 0  Duplicates: 0  Warnings: 0

mysql> explain analyze SELECT 1 FROM beatmaps WHERE file_name = 'kozato - Rengetsu Ouka (ktgster) [O].osu'\G
*************************** 1. row ***************************
EXPLAIN: -> Covering index lookup on beatmaps using file_name (file_name='kozato - Rengetsu Ouka (ktgster) [O].osu')  (cost=1.1 rows=1) (actual time=0.0171..0.0171 rows=0 loops=1)

1 row in set (0.00 sec)
```