### PR TITLE
Remove unused indices on large user_profile_history table

### DIFF
--- a/migrations/0007_remove_unused_profile_history_indices.up.sql
+++ b/migrations/0007_remove_unused_profile_history_indices.up.sql
@@ -1,0 +1,4 @@
+alter table user_profile_history drop index rank;
+alter table user_profile_history drop index rank_2;
+alter table user_profile_history drop index captured_at;
+alter table user_profile_history drop index user_id_2;


### PR DESCRIPTION
The `sys.schema_unused_indexes` table in mysql suggests these are unused:
```sql
mysql> select * from sys.schema_unused_indexes where object_name = 'user_profile_history';
+---------------+----------------------+-------------+
| object_schema | object_name          | index_name  |
+---------------+----------------------+-------------+
| akatsuki      | user_profile_history | user_id_2   |
| akatsuki      | user_profile_history | captured_at |
| akatsuki      | user_profile_history | rank_2      |
| akatsuki      | user_profile_history | rank        |
+---------------+----------------------+-------------+
4 rows in set (0.03 sec)
```

They're also quite large, as this table is >20M records:

![image](https://i.cmyui.xyz/X8kvVGDiy3HTxU0GlrY4.png)