### PR TITLE
Add `leaderboard_size` column to `users` table

### DIFF
--- a/migrations/0012_add_leaderboard_size.up.sql
+++ b/migrations/0012_add_leaderboard_size.up.sql
@@ -1,0 +1,1 @@
+alter table users add column leaderboard_size int null;


### PR DESCRIPTION
Will be used across multiple components

- [score-service PR](https://github.com/osuAkatsuki/score-service/pull/127)
- hanayo PR
- [akatsuki-api PR](https://github.com/osuAkatsuki/akatsuki-api/pull/71)