### PR TITLE
Add Twitch account fields to users

### DIFF
--- a/migrations/0028_add_twitch_account_to_users.up.sql
+++ b/migrations/0028_add_twitch_account_to_users.up.sql
@@ -1,0 +1,6 @@
+alter table users
+  add column twitch_account_id varchar(32) null default null,
+  add column twitch_username varchar(25) null default null,
+  add column twitch_display_name varchar(64) null default null,
+  add unique key users_twitch_account_id_unique (twitch_account_id),
+  add key users_twitch_username_idx (twitch_username);

--- a/migrations/0028_add_twitch_account_to_users.up.sql
+++ b/migrations/0028_add_twitch_account_to_users.up.sql
@@ -1,6 +1,5 @@
 alter table users
   add column twitch_account_id varchar(32) null default null,
   add column twitch_username varchar(25) null default null,
-  add column twitch_display_name varchar(64) null default null,
   add unique key users_twitch_account_id_unique (twitch_account_id),
   add key users_twitch_username_idx (twitch_username);


### PR DESCRIPTION
## Summary
- add Twitch account id, username, and display name columns to users
- enforce one Akatsuki account per Twitch account
- index Twitch username lookup for the bot

## Testing
- git diff --check