### PR TITLE
Add official osu account link fields

### DIFF
--- a/migrations/0029_add_official_osu_account_to_users.up.sql
+++ b/migrations/0029_add_official_osu_account_to_users.up.sql
@@ -1,0 +1,5 @@
+alter table users
+  add column official_osu_user_id int unsigned null default null,
+  add column official_osu_username varchar(32) null default null,
+  add unique key users_official_osu_user_id_unique (official_osu_user_id),
+  add key users_official_osu_username_idx (official_osu_username);


### PR DESCRIPTION
## Summary
- add official_osu_user_id to users with a unique index
- add official_osu_username as a display cache
- add a username index for lookup/display support

## Notes
- official_osu_user_id is the stable source of truth; username is cached because osu! usernames can change

## Tests
- git diff --check