### PR TITLE
Add IP last-used timestamp

### DIFF
--- a/migrations/0030_add_ip_user_last_used_at.up.sql
+++ b/migrations/0030_add_ip_user_last_used_at.up.sql
@@ -1,0 +1,1 @@
+alter table ip_user add column last_used_at datetime null default null;


### PR DESCRIPTION
## Summary
- add nullable ip_user.last_used_at for future IP usage timestamps
- keep existing historical IP rows as NULL rather than inventing timestamps

## Verification
- bash tests/test-migration-sequentiality.sh

## Rollout
Merge/deploy before the bancho-service-rs and admin-panel PRs that write/read last_used_at.