### PR TITLE
Allow shared account connection identifiers

### DIFF
--- a/migrations/0031_allow_shared_account_connections.up.sql
+++ b/migrations/0031_allow_shared_account_connections.up.sql
@@ -1,0 +1,6 @@
+alter table users
+  add key users_discord_account_id_idx (discord_account_id),
+  drop index users_twitch_account_id_unique,
+  add key users_twitch_account_id_idx (twitch_account_id),
+  drop index users_official_osu_user_id_unique,
+  add key users_official_osu_user_id_idx (official_osu_user_id);


### PR DESCRIPTION
## Summary
- drop unique indexes from Twitch and osu account connection identifiers
- replace them with non-unique lookup indexes
- add a non-unique Discord account ID lookup index for parity

## Verification
- bash tests/test-migration-sequentiality.sh