### PR TITLE
Migrate Docker image references to GHCR

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -13,15 +13,19 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out latest commit
         uses: actions/checkout@v7
 
-      - name: Log in to Docker Hub
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7
@@ -30,8 +34,8 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/mysql-database:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/mysql-database:${{ github.sha }}
+            ghcr.io/osuakatsuki/mysql-database:latest
+            ghcr.io/osuakatsuki/mysql-database:${{ github.sha }}
 
       - name: Run migrations on production
         uses: appleboy/ssh-action@v1
@@ -41,7 +45,7 @@ jobs:
           key: ${{ secrets.SERVER_SSH_KEY }}
           script: |
             cd /opt/akatsuki
-            docker pull osuakatsuki/mysql-database:latest
+            docker pull ghcr.io/osuakatsuki/mysql-database:latest
             source .env
             docker run --rm \
               --add-host=host.docker.internal:host-gateway \
@@ -49,4 +53,4 @@ jobs:
               -e APP_ENV=production \
               -e VAULT_ADDR=http://host.docker.internal:8200 \
               -e VAULT_TOKEN=$VAULT_TOKEN \
-              osuakatsuki/mysql-database:latest
+              ghcr.io/osuakatsuki/mysql-database:latest


### PR DESCRIPTION
## Summary
- point Docker image references at `ghcr.io/osuakatsuki/...`
- replace Docker Hub auth/tags with GHCR + `GITHUB_TOKEN` where this repo publishes images

## Verification
- parsed changed YAML with PyYAML
- ran `git diff --check` on changed worktrees, allowing `cr-at-eol` for existing CRLF workflow files
- scanned touched worktrees for remaining Docker Hub publish/image references